### PR TITLE
Add Docker support to infping

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+from golang:1.6
+
+RUN apt-get update
+RUN apt-get install fping
+
+ADD ./bin/infping /go/bin/infping
+
+CMD infping
+

--- a/infhttp.go
+++ b/infhttp.go
@@ -4,7 +4,7 @@
 package main
 
 import (
-    "github.com/influxdb/influxdb/client"
+    "github.com/influxdata/influxdb/client"
     "github.com/pelletier/go-toml"
     "fmt"
     "log"
@@ -81,7 +81,7 @@ func writePoints(config *toml.TomlTree, con *client.Client, url string, code int
 }
 
 func main() {
-    config, err := toml.LoadFile("config.toml")
+    config, err := toml.LoadFile("/etc/config.toml")
     if err != nil {
         fmt.Println("Error:", err.Error())
         os.Exit(1)

--- a/infping.go
+++ b/infping.go
@@ -4,7 +4,7 @@
 package main
 
 import (
-    "github.com/influxdb/influxdb/client"
+    "github.com/influxdata/influxdb/client"
     "github.com/pelletier/go-toml"
     "fmt"
     "log"
@@ -121,7 +121,7 @@ func writePoints(config *toml.TomlTree, con *client.Client, host string, sent st
 }
 
 func main() {
-    config, err := toml.LoadFile("config.toml")
+    config, err := toml.LoadFile("/etc/config.toml")
     if err != nil {
         fmt.Println("Error:", err.Error())
         os.Exit(1)


### PR DESCRIPTION
Changed the URL from influxdb to influxdata to fix the client import
errors, at some stage this will need changing to v2.

Changed the configuration option from ./config.toml to
/etc/config.toml.

Add Dockerfile which will allow us to run this from Docker containers
and allow for us to deploy this at scale
